### PR TITLE
Fix: Correct JSON syntax error in data.geojson

### DIFF
--- a/data.geojson
+++ b/data.geojson
@@ -52,7 +52,7 @@
         "type": "Point",
         "coordinates": [16.4402, 43.5081]
       },
-      "properties":.
+      "properties": {
         "name": "Diocletian's Palace",
         "category": "historical",
         "rating": 4.7,

--- a/map.js
+++ b/map.js
@@ -40,5 +40,11 @@ fetchData()
         console.log("Map initialized and data loading initiated with custom icons logic.");
     })
     .catch(error => {
-        console.error('Error fetching or processing GeoJSON data:', error);
+        console.error('Failed to load site data. See details below.');
+        if (error instanceof SyntaxError) {
+            console.error('JSON Parsing Error:', error.message);
+            console.error('This is likely due to a syntax error in data.geojson.');
+        } else {
+            console.error('Network or other error:', error);
+        }
     });


### PR DESCRIPTION
A syntax error in `data.geojson` (a period instead of an opening curly brace) caused the application to fail on load because the JSON data could not be parsed. This commit corrects the error.

Additionally, the error handling in `map.js` has been enhanced to provide more specific diagnostics for future data-related issues, distinguishing between JSON parsing errors and other network failures.